### PR TITLE
Enhance toc running indicator

### DIFF
--- a/packages/toc/src/generators/markdown/options_manager.ts
+++ b/packages/toc/src/generators/markdown/options_manager.ts
@@ -38,7 +38,7 @@ interface IOptions {
  *
  * @private
  */
-class OptionsManager extends Registry.IOptionsManager {
+class OptionsManager implements Registry.IOptionsManager {
   /**
    * Returns an options manager.
    *
@@ -47,7 +47,6 @@ class OptionsManager extends Registry.IOptionsManager {
    * @returns options manager
    */
   constructor(widget: TableOfContents, options: IOptions) {
-    super();
     this._numbering = options.numbering;
     this._numberingH1 = options.numberingH1;
     this._widget = widget;

--- a/packages/toc/src/generators/notebook/append_heading.ts
+++ b/packages/toc/src/generators/notebook/append_heading.ts
@@ -15,7 +15,7 @@ import { isHeadingFiltered } from './is_heading_filtered';
  * @param tags - filter tags
  * @returns result tuple
  */
-function appendHeading(
+export function appendHeading(
   headings: INotebookHeading[],
   heading: INotebookHeading,
   prev: INotebookHeading | null,
@@ -24,12 +24,17 @@ function appendHeading(
 ): [INotebookHeading[], INotebookHeading | null] {
   if (heading && !isHeadingFiltered(heading, tags) && heading.text) {
     // Determine whether this heading is a child of a "header" notebook heading...
-    if (prev && prev.type === 'header') {
-      for (let j = headings.length - 1; j >= 0; j--) {
-        if (headings[j] === prev) {
-          // TODO: can a heading be the child of multiple headings? If not, we can `break` here upon finding a parent heading, so we don't traverse the entire heading list...
-          headings[j].hasChild = true;
-        }
+    for (let j = headings.length - 1; j >= 0; j--) {
+      if (prev?.type === 'header' && headings[j] === prev) {
+        // TODO: can a heading be the child of multiple headings? If not, we can `break` here upon finding a parent heading, so we don't traverse the entire heading list...
+        headings[j].hasChild = true;
+      }
+      if (headings[j].hasChild) {
+        headings[j].isRunning = Math.max(
+          headings[j].isRunning,
+          heading.isRunning
+        );
+        break;
       }
     }
     if (collapseLevel < 0) {
@@ -39,8 +44,3 @@ function appendHeading(
   }
   return [headings, prev];
 }
-
-/**
- * Exports.
- */
-export { appendHeading };

--- a/packages/toc/src/generators/notebook/get_code_cell_heading.ts
+++ b/packages/toc/src/generators/notebook/get_code_cell_heading.ts
@@ -2,7 +2,7 @@
 // Distributed under the terms of the Modified BSD License.
 
 import { Cell } from '@jupyterlab/cells';
-import { INotebookHeading } from '../../utils/headings';
+import { INotebookHeading, RunningStatus } from '../../utils/headings';
 
 /**
  * Returns a "click" handler.
@@ -31,7 +31,8 @@ function getCodeCellHeading(
   executionCount: string,
   lastLevel: number,
   cellRef: Cell,
-  index: number = -1
+  index: number = -1,
+  isRunning = RunningStatus.Idle
 ): INotebookHeading {
   let headings: INotebookHeading[] = [];
   if (index === -1) {
@@ -57,7 +58,7 @@ function getCodeCellHeading(
       cellRef: cellRef,
       hasChild: false,
       index: index,
-      running: false
+      isRunning
     });
   }
   return headings[0];

--- a/packages/toc/src/generators/notebook/get_markdown_heading.ts
+++ b/packages/toc/src/generators/notebook/get_markdown_heading.ts
@@ -3,7 +3,7 @@
 
 import { Cell } from '@jupyterlab/cells';
 import { generateNumbering } from '../../utils/generate_numbering';
-import { INotebookHeading } from '../../utils/headings';
+import { INotebookHeading, RunningStatus } from '../../utils/headings';
 import { INumberingDictionary } from '../../utils/numbering_dictionary';
 import { parseHeading } from '../../utils/parse_heading';
 
@@ -34,7 +34,8 @@ function getMarkdownHeadings(
   dict: INumberingDictionary,
   lastLevel: number,
   cellRef: Cell,
-  index: number = -1
+  index: number = -1,
+  isRunning = RunningStatus.Idle
 ): INotebookHeading[] {
   const callback = onClick(0);
   let headings: INotebookHeading[] = [];
@@ -54,7 +55,7 @@ function getMarkdownHeadings(
         type: 'header',
         cellRef: cellRef,
         hasChild: false,
-        running: false,
+        isRunning,
         index
       });
     } else {
@@ -65,7 +66,7 @@ function getMarkdownHeadings(
         type: 'markdown',
         cellRef: cellRef,
         hasChild: false,
-        running: false,
+        isRunning,
         index
       });
     }

--- a/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
+++ b/packages/toc/src/generators/notebook/get_rendered_html_heading.ts
@@ -4,7 +4,7 @@
 import { ISanitizer } from '@jupyterlab/apputils';
 import { Cell } from '@jupyterlab/cells';
 import { generateNumbering } from '../../utils/generate_numbering';
-import { INotebookHeading } from '../../utils/headings';
+import { INotebookHeading, RunningStatus } from '../../utils/headings';
 import { INumberingDictionary } from '../../utils/numbering_dictionary';
 import { sanitizerOptions } from '../../utils/sanitizer_options';
 
@@ -40,7 +40,8 @@ function getRenderedHTMLHeadings(
   numbering = false,
   numberingH1 = true,
   cellRef: Cell,
-  index: number = -1
+  index: number = -1,
+  isRunning = RunningStatus.Idle
 ): INotebookHeading[] {
   let nodes = node.querySelectorAll('h1, h2, h3, h4, h5, h6, p');
 
@@ -67,7 +68,7 @@ function getRenderedHTMLHeadings(
           cellRef: cellRef,
           hasChild: false,
           index: index,
-          running: false
+          isRunning
         });
       }
       continue;
@@ -99,7 +100,7 @@ function getRenderedHTMLHeadings(
       cellRef: cellRef,
       hasChild: false,
       index: index,
-      running: false
+      isRunning
     });
   }
   return headings;

--- a/packages/toc/src/generators/notebook/options_manager.ts
+++ b/packages/toc/src/generators/notebook/options_manager.ts
@@ -8,7 +8,6 @@ import { ISignal, Signal } from '@lumino/signaling';
 import { TableOfContentsRegistry as Registry } from '../../registry';
 import { TableOfContents } from '../../toc';
 import { TagsToolComponent } from './tagstool';
-import { Cell } from '@jupyterlab/cells';
 
 /**
  * Interface describing constructor options.
@@ -46,11 +45,6 @@ interface IOptions {
    * The application language translator.
    */
   translator?: ITranslator;
-
-  /**
-   * Array to keep track of currently running cells.
-   */
-  running?: [Cell];
 }
 
 /**
@@ -58,7 +52,7 @@ interface IOptions {
  *
  * @private
  */
-class OptionsManager extends Registry.IOptionsManager {
+class OptionsManager implements Registry.IOptionsManager {
   /**
    * Returns an options manager.
    *
@@ -72,7 +66,6 @@ class OptionsManager extends Registry.IOptionsManager {
     notebook: INotebookTracker,
     options: IOptions
   ) {
-    super();
     this._numbering = options.numbering;
     this._numberingH1 = options.numberingH1;
     this._includeOutput = options.includeOutput;
@@ -81,7 +74,6 @@ class OptionsManager extends Registry.IOptionsManager {
     this._notebook = notebook;
     this.sanitizer = options.sanitizer;
     this.storeTags = [];
-    this.running = [];
     this.translator = options.translator || nullTranslator;
     this._collapseChanged = new Signal<this, Registry.ICollapseChangedArgs>(
       this
@@ -307,8 +299,7 @@ class OptionsManager extends Registry.IOptionsManager {
   private _collapseChanged: Signal<this, Registry.ICollapseChangedArgs>;
   private _tagTool: TagsToolComponent | null = null;
   translator: ITranslator; // FIXME-TRANS:
-  public storeTags: string[];
-  public running: Cell[];
+  storeTags: string[];
 }
 
 /**

--- a/packages/toc/src/registry.ts
+++ b/packages/toc/src/registry.ts
@@ -90,7 +90,7 @@ export namespace TableOfContentsRegistry {
   /**
    * Abstract class for managing options affecting how a table of contents is generated for a particular widget type.
    */
-  export abstract class IOptionsManager {}
+  export interface IOptionsManager {}
 
   /**
    * Interface for the arguments needed in the collapse signal of a generator

--- a/packages/toc/src/utils/headings.ts
+++ b/packages/toc/src/utils/headings.ts
@@ -5,10 +5,8 @@ import { Cell } from '@jupyterlab/cells';
 
 /**
  * Interface describing a heading.
- *
- * @private
  */
-interface IHeading {
+export interface IHeading {
   /**
    * Heading text.
    */
@@ -41,10 +39,8 @@ interface IHeading {
 
 /**
  * Interface describing a numbered heading.
- *
- * @private
  */
-interface INumberedHeading extends IHeading {
+export interface INumberedHeading extends IHeading {
   /**
    * Heading numbering.
    */
@@ -52,11 +48,27 @@ interface INumberedHeading extends IHeading {
 }
 
 /**
- * Interface describing a notebook cell heading.
- *
- * @private
+ * Cell running status
  */
-interface INotebookHeading extends INumberedHeading {
+export enum RunningStatus {
+  /**
+   * Cell is idle
+   */
+  Idle = -1,
+  /**
+   * Cell execution is scheduled
+   */
+  Scheduled = 0,
+  /**
+   * Cell is running
+   */
+  Running = 1
+}
+
+/**
+ * Interface describing a notebook cell heading.
+ */
+export interface INotebookHeading extends INumberedHeading {
   /**
    * Heading type.
    */
@@ -83,9 +95,9 @@ interface INotebookHeading extends INumberedHeading {
   index: number;
 
   /**
-   * Boolean indicating whether a heading has a running cell under it
+   * Running status of the cells in the heading
    */
-  running: boolean;
+  isRunning: RunningStatus;
 }
 
 /**
@@ -94,15 +106,6 @@ interface INotebookHeading extends INumberedHeading {
  * @param heading - heading to test
  * @returns boolean indicating whether a heading is a notebook heading
  */
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-const isNotebookHeading = (heading: any): boolean => {
+export function isNotebookHeading(heading: any): boolean {
   return heading.type !== undefined && heading.cellRef !== undefined;
-};
-
-/**
- * Exports.
- */
-export { IHeading };
-export { INumberedHeading };
-export { INotebookHeading };
-export { isNotebookHeading };
+}

--- a/packages/toc/style/base.css
+++ b/packages/toc/style/base.css
@@ -332,6 +332,8 @@
 .toc-cell-item {
   padding-left: 10px;
   font-size: var(--jp-ui-font-size1);
+  /* Push ellipse button and execution indicator to right */
+  margin-right: auto;
 }
 
 /* styles for tags */
@@ -382,31 +384,40 @@
   padding-top: 6px;
 }
 
-.toc-Indicators {
-  margin-left: auto;
-  display: flex;
-}
-
-.toc-Running {
-  height: 16px;
-  padding-right: 1px;
-  padding-left: 1px;
-  position: relative;
-  margin-left: -30px;
-}
-
 .toc-Ellipses {
+  box-sizing: border-box;
   height: 16px;
-  padding-right: 1px;
-  padding-left: 1px;
-  position: relative;
-  margin-right: -13px;
 }
 
 .toc-Ellipses:hover {
-  border: 1px solid var(--jp-border-color1);
+  border: var(--jp-border-width) solid var(--jp-border-color1);
   box-shadow: 0px 0px 2px 0px rgba(0, 0, 0, 0.25);
   background-color: var(--jp-layout-color0);
+}
+
+/*
+ * Execution indicator
+ */
+.toc-entry-holder::after {
+  content: '';
+  /* Must be identical to form a circle */
+  width: 12px;
+  height: 12px;
+  margin: 2px;
+  background: none;
+  border: none;
+}
+
+.toc-entry-holder[data-running='0']::after {
+  border-radius: 50%;
+  border: var(--jp-border-width) solid var(--jp-inverse-layout-color3);
+  background: none;
+}
+
+.toc-entry-holder[data-running='1']::after {
+  border-radius: 50%;
+  border: var(--jp-border-width) solid var(--jp-inverse-layout-color3);
+  background-color: var(--jp-inverse-layout-color3);
 }
 
 /* 


### PR DESCRIPTION
Hey @andrewfulton9 

I went for proposing a PR because I wanted to take the chance to improve the code structure a bit at the same time.

What I did compare to the head:
- Make the notebook toc generator as a class so it clarify it
- Store the running cells array in that new generator class (as it does not make really sense in the options container)
- Use a three state `isRunning` attribute on the heading to distinguish: _Idle_, _Scheduled_, _Running_
- Set `data-running` attribute on the toc item with the `isRunning` status
- Use pure CSS to define the indicator, so that it can be tuned easily.
- Add '*' to the scheduled/running prompts if code cell are displayed.
